### PR TITLE
Add namespace to support gradle 8.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.sumsg.getsettings'
     compileSdk 31
 
     compileOptions {


### PR DESCRIPTION
## Description
* Added namespace

## Context
I got a error below when I tried to build on android with gradle 8.x version.
```
1: Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring project ':get_settings'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```